### PR TITLE
Mark compatible with WordPress 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -48,6 +48,7 @@ Enable, enjoy!
 
 = 1.0.11 =
 * Confirm compatibility with WordPress 7.1.
+* Fix an "Undefined array key" warning when picking a theme to install. `array_diff()` preserves the original keys, so the randomly chosen index often did not exist.
 
 = 0.1.4 =
 * Fix authorship

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors:      adamsilverstein
 Donate link:       http://wordpress.org/plugins
 Tags:
 Requires at least: 3.9
-Tested up to:      5.8
-Stable tag:        1.0.10
+Tested up to:      7.1
+Stable tag:        1.0.11
 License:           MIT
 License URI:       https://opensource.org/licenses/MIT
 
@@ -45,6 +45,9 @@ Enable, enjoy!
 
 
 == Changelog ==
+
+= 1.0.11 =
+* Confirm compatibility with WordPress 7.1.
 
 = 0.1.4 =
 * Fix authorship

--- a/theme-roulette.php
+++ b/theme-roulette.php
@@ -137,7 +137,8 @@ function thmr_maybe_change_theme() {
 					/**
 					 * Randomly select one of the remaining themes and install.
 					 */
-					$theme_index_to_install = rand( 1, sizeof( $uninstalled_themes ) );
+					$uninstalled_themes     = array_values( $uninstalled_themes );
+					$theme_index_to_install = rand( 0, sizeof( $uninstalled_themes ) - 1 );
 					$theme_to_install       = $uninstalled_themes[ $theme_index_to_install ];
 					$title                  = $theme_to_install;
 					$plugin                 = $theme_to_install;

--- a/theme-roulette.php
+++ b/theme-roulette.php
@@ -3,7 +3,7 @@
 Plugin Name: Theme Roulette
 Plugin URI:  http://wordpress.org/plugins/theme-roulette
 Description: A random theme at random times.
-Version:     1.0.10
+Version:     1.0.11
 Author:      Adam Silverstein
 License:     MIT
 Text Domain: thmr


### PR DESCRIPTION
_Claude took a deep dive on this one and came up with this:_

Bumps `Tested up to` to 7.1 and cuts 1.0.11 so the update reaches the plugin directory.

Testing against 7.1 surfaced a real bug, fixed here too:

```
PHP Warning: Undefined array key 79 in theme-roulette.php on line 141
```

`array_diff()` preserves the keys of its first argument, so `$uninstalled_themes` is sparsely keyed &mdash; indexing it with a freshly generated random integer usually misses. The range was off by one as well (`rand( 1, sizeof( ... ) )` on a zero-based array). The fix reindexes with `array_values()` before picking, which is exactly what the theme *activation* path a few lines above already does.

When the key missed, `$theme_to_install` came back null and the install silently did nothing, so this was suppressing the plugin's whole reason for existing, not just emitting a warning.

### Testing

Verified against WordPress 7.1-RC3 in wp-env on PHP 8.3, with `WP_DEBUG` on and this plugin the only one active:

- Before the fix: the warning above appeared in `debug.log` on loading Appearance &rarr; Themes.
- After the fix: four page loads, `debug.log` clean, no JavaScript console or page errors, and the plugin successfully installed and switched to a random theme from the directory.

## AI Use

Code and description both written with 🤖 Claude Code. I will review and test.
